### PR TITLE
fix bytes/string erros

### DIFF
--- a/lib/camlp4_to_ppx.ml
+++ b/lib/camlp4_to_ppx.ml
@@ -31,7 +31,7 @@ let file_contents =
   let len = in_channel_length ic in
   let str = Bytes.create len in
   really_input ic str 0 len;
-  str
+  Bytes.to_string str
 
 type subst =
   { start : int


### PR DESCRIPTION
File "lib/camlp4_to_ppx.ml", line 48, characters 30-43:
Error: This expression has type bytes but an expression was expected of type
         string
Command exited with code 2.